### PR TITLE
Simplify test scope

### DIFF
--- a/elasticsearch/src/test/java/org/trellisldp/ext/elasticsearch/ElasticsearchRouterTest.java
+++ b/elasticsearch/src/test/java/org/trellisldp/ext/elasticsearch/ElasticsearchRouterTest.java
@@ -32,7 +32,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.junit.Test;
 
-public class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
+class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
 
     @EndpointInject(uri = "mock:results")
     protected MockEndpoint resultEndpoint;
@@ -66,7 +66,7 @@ public class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testUpdate() throws Exception {
+    void testUpdate() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisLdpathFormatter", builder -> {
             builder.mockEndpointsAndSkip("http*");
         });
@@ -92,7 +92,7 @@ public class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testFetch() throws Exception {
+    void testFetch() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisLdpathFormatter", builder -> {
             builder.mockEndpointsAndSkip("http*");
             builder.mockEndpointsAndSkip("direct:update.elasticsearch");
@@ -113,7 +113,7 @@ public class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    void testDelete() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisElasticsearchDeleter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -133,7 +133,7 @@ public class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testNotActivityMessage() throws Exception {
+    void testNotActivityMessage() throws Exception {
         context.start();
 
         resultEndpoint.expectedMessageCount(0);
@@ -144,7 +144,7 @@ public class ElasticsearchRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testNotJson() throws Exception {
+    void testNotJson() throws Exception {
         context.start();
 
         resultEndpoint.expectedMessageCount(0);

--- a/ldpath/src/test/java/org/trellisldp/ext/ldpath/LDPathRouterTest.java
+++ b/ldpath/src/test/java/org/trellisldp/ext/ldpath/LDPathRouterTest.java
@@ -34,7 +34,7 @@ import org.apache.camel.test.AvailablePortFinder;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.junit.Test;
 
-public class LDPathRouterTest extends CamelBlueprintTestSupport {
+class LDPathRouterTest extends CamelBlueprintTestSupport {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final int TEST_PORT = AvailablePortFinder.getNextAvailable();
@@ -68,7 +68,7 @@ public class LDPathRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testQuery() throws Exception {
+    void testQuery() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisLDPathQuery", builder -> {
             builder.weaveAddLast().to("mock:results");
         });

--- a/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
+++ b/osgi/src/test/java/org/trellisldp/osgi/OSGiTest.java
@@ -49,7 +49,7 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
-public class OSGiTest {
+class OSGiTest {
 
     @Inject
     protected FeaturesService featuresService;
@@ -58,7 +58,7 @@ public class OSGiTest {
     protected BundleContext bundleContext;
 
     @Configuration
-    public Option[] config() {
+    Option[] config() {
         final ConfigurationManager cm = new ConfigurationManager();
         final String rmiRegistryPort = cm.getProperty("karaf.rmiRegistry.port");
         final String rmiServerPort = cm.getProperty("karaf.rmiServer.port");
@@ -94,7 +94,7 @@ public class OSGiTest {
     }
 
     @Test
-    public void testWebSubInstallation() throws Exception {
+    void testWebSubInstallation() throws Exception {
         assertFalse("camel-ldp-websub already installed!",
                 featuresService.isInstalled(featuresService.getFeature("camel-ldp-websub")));
         featuresService.installFeature("camel-ldp-websub");
@@ -106,7 +106,7 @@ public class OSGiTest {
     }
 
     @Test
-    public void testLDPathInstallation() throws Exception {
+    void testLDPathInstallation() throws Exception {
         assertFalse("camel-ldp-ldpath already installed!",
                 featuresService.isInstalled(featuresService.getFeature("camel-ldp-ldpath")));
         featuresService.installFeature("camel-ldp-ldpath");
@@ -118,7 +118,7 @@ public class OSGiTest {
     }
 
     @Test
-    public void testTriplestoreInstallation() throws Exception {
+    void testTriplestoreInstallation() throws Exception {
         assertFalse("camel-ldp-triplestore already installed!",
                 featuresService.isInstalled(featuresService.getFeature("camel-ldp-triplestore")));
         featuresService.installFeature("camel-ldp-triplestore");
@@ -130,7 +130,7 @@ public class OSGiTest {
     }
 
     @Test
-    public void testElasticSearchInstallation() throws Exception {
+    void testElasticSearchInstallation() throws Exception {
         assertFalse("camel-ldp-elasticsearch already installed!",
                 featuresService.isInstalled(featuresService.getFeature("camel-ldp-elasticsearch")));
         featuresService.installFeature("camel-ldp-elasticsearch");

--- a/triplestore/src/test/java/org/trellisldp/ext/triplestore/TriplestoreRouterTest.java
+++ b/triplestore/src/test/java/org/trellisldp/ext/triplestore/TriplestoreRouterTest.java
@@ -34,7 +34,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.junit.Test;
 
-public class TriplestoreRouterTest extends CamelBlueprintTestSupport {
+class TriplestoreRouterTest extends CamelBlueprintTestSupport {
 
     @EndpointInject(uri = "mock:results")
     protected MockEndpoint resultEndpoint;
@@ -66,7 +66,7 @@ public class TriplestoreRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testUpdate() throws Exception {
+    void testUpdate() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisTriplestoreUpdater", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -95,7 +95,7 @@ public class TriplestoreRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    void testDelete() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisTriplestoreDeleter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -117,7 +117,7 @@ public class TriplestoreRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testNotActivityMessage() throws Exception {
+    void testNotActivityMessage() throws Exception {
         context.start();
 
         resultEndpoint.expectedMessageCount(0);
@@ -128,7 +128,7 @@ public class TriplestoreRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testNotJson() throws Exception {
+    void testNotJson() throws Exception {
         context.start();
 
         resultEndpoint.expectedMessageCount(0);

--- a/triplestore/src/test/java/org/trellisldp/ext/triplestore/TriplestoreUtilsTest.java
+++ b/triplestore/src/test/java/org/trellisldp/ext/triplestore/TriplestoreUtilsTest.java
@@ -19,20 +19,20 @@ import java.io.UncheckedIOException;
 
 import org.junit.Test;
 
-public class TriplestoreUtilsTest {
+class TriplestoreUtilsTest {
 
     @Test
-    public void testEncode() {
+    void testEncode() {
         assertEquals("", TriplestoreUtils.encode(null, "foo"));
     }
 
     @Test(expected = UncheckedIOException.class)
-    public void testNonexistentEncoding() {
+    void testNonexistentEncoding() {
         TriplestoreUtils.encode("a value", "non-existent-encoding");
     }
 
     @Test
-    public void testEncodeRealValue() {
+    void testEncodeRealValue() {
         assertEquals("a+value+with+spaces", TriplestoreUtils.encode("a value with spaces", "UTF-8"));
     }
 }

--- a/websub/src/test/java/org/trellisldp/ext/websub/WebSubRouterTest.java
+++ b/websub/src/test/java/org/trellisldp/ext/websub/WebSubRouterTest.java
@@ -30,7 +30,7 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.junit.Test;
 
-public class WebSubRouterTest extends CamelBlueprintTestSupport {
+class WebSubRouterTest extends CamelBlueprintTestSupport {
 
     @EndpointInject(uri = "mock:results")
     protected MockEndpoint resultEndpoint;
@@ -62,7 +62,7 @@ public class WebSubRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testUpdate() throws Exception {
+    void testUpdate() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisWebSubRouter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -83,7 +83,7 @@ public class WebSubRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testCreate() throws Exception {
+    void testCreate() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisWebSubRouter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -105,7 +105,7 @@ public class WebSubRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    void testDelete() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisWebSubRouter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -120,7 +120,7 @@ public class WebSubRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testNotActivityMessage() throws Exception {
+    void testNotActivityMessage() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisWebSubRouter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");
@@ -135,7 +135,7 @@ public class WebSubRouterTest extends CamelBlueprintTestSupport {
     }
 
     @Test
-    public void testNotJson() throws Exception {
+    void testNotJson() throws Exception {
         AdviceWithRouteBuilder.adviceWith(context, "TrellisWebSubRouter", builder -> {
             builder.weaveAddLast().to("mock:results");
             builder.mockEndpointsAndSkip("http*");


### PR DESCRIPTION
JUnit tests don't need `public` scope